### PR TITLE
turn on dbz analysis in RRFSv2x for HWT 

### DIFF
--- a/parm/hrrrv5/namelist.init_atmosphere
+++ b/parm/hrrrv5/namelist.init_atmosphere
@@ -54,6 +54,10 @@
 &physics
     config_tsk_seaice_threshold = 271.4
 /
+&lbcs
+    config_lbc_hydrometeors_rrfs = ${lbc_hydrometeors_rrfs}
+    config_lbc_hydrometeors_gfs = ${lbc_hydrometeors_gfs}
+/
 &io
     config_pio_num_iotasks = 0
     config_pio_stride = 1

--- a/parm/jedivar.yaml
+++ b/parm/jedivar.yaml
@@ -158,6 +158,7 @@ cost function:
            engine:
              type: H5File
              obsfile: data/obs/ioda_mrms_refl.nc
+             missing file action: "warn"
          obsdataout:
            engine:
              type: H5File

--- a/scripts/exrrfs_lbc.sh
+++ b/scripts/exrrfs_lbc.sh
@@ -29,6 +29,9 @@ start_time=$(date -d "${EDATE:0:8} ${EDATE:8:2}" +%Y-%m-%d_%H:%M:%S)
 EDATE=$(${NDATE} "${fhr_end}" "${CDATEin}")
 end_time=$(date -d "${EDATE:0:8} ${EDATE:8:2}" +%Y-%m-%d_%H:%M:%S)
 
+lbc_hydrometeors_rrfs=true
+lbc_hydrometeors_gfs=false
+
 if [[ "${prefix}" == "RAP" || "${prefix}" == "HRRR" ]]; then
   nfglevels=51
   nfgsoillevels=9
@@ -38,9 +41,13 @@ elif  [[ "${prefix}" == "RRFS" ]]; then
 elif  [[ "${prefix}" == "GFS" ]]; then
   nfglevels=58
   nfgsoillevels=4
+  lbc_hydrometeors_rrfs=false
+  lbc_hydrometeors_gfs=true
 elif  [[ "${prefix}" == "GEFS" ]]; then
   nfglevels=32
   nfgsoillevels=4
+  lbc_hydrometeors_rrfs=false
+  lbc_hydrometeors_gfs=false
 fi
 nsoillevels=${NSOIL_LEVELS}
 

--- a/workflow/exp/rt_ursa/exp.rrfsv2x
+++ b/workflow/exp/rt_ursa/exp.rrfsv2x
@@ -24,7 +24,7 @@ export SNUDGETYPES="GGG" # G=gsd_update_soiltq from GSI; P=2022 J Hydro paper; c
 export COLDSTART_CYCS_DO_DA=false #true
 export DO_NONVAR_CLOUD_ANA=true
 export DO_CHEMISTRY=false
-export DO_RADAR_REF=false  # does not work for 3DVar, only EnVar or GETKF
+export DO_RADAR_REF=true  # does not work for 3DVar, only EnVar or GETKF
 export RADARREFL_TIMELEVEL="00"  # 00 15 30 45 min
 export HYB_WGT_ENS=0.5
 export HYB_WGT_STATIC=0.5

--- a/workflow/sideload/launch.sh
+++ b/workflow/sideload/launch.sh
@@ -41,7 +41,7 @@ if [[ ${MACHINE,,} == "ursa" ]]; then # special needs at ursa
   export I_MPI_ADJUST_GATHERV=2
   export I_MPI_ADJUST_SCATTER=2
   export I_MPI_ADJUST_SCATTERV=2
-  export I_MPI_COLL_INTRANODE=pt2pt
+#  export I_MPI_COLL_INTRANODE=pt2pt
 fi
 #
 echo "load rrfs-workflow modules by default"


### PR DESCRIPTION
1) Turn on radar dbz analysis for 3DEnVar analysis in RRFS
2) Add options to control hydrometeor in boundary file based on source model type
3) Comment out "export I_MPI_COLL_INTRANODE=pt2pt" for all tasks.
4) Make mrms data file as option in JEDI analysis